### PR TITLE
Ruby 3 support

### DIFF
--- a/lib/devise/autosigninable.rb
+++ b/lib/devise/autosigninable.rb
@@ -10,6 +10,16 @@ else
   end
 end
 
+module Devise
+  # Indicator: expire autosignin token.
+  mattr_accessor :autosignin_expire
+  @@autosignin_expire = false
+
+  # The number of retries for autosignin token generation.
+  mattr_accessor :autosignin_generation_retry_count
+  @@autosignin_generation_retry_count = 20
+end
+
 Devise.add_module :autosigninable,
                   controller: :autosignin,
                   model: 'devise/autosigninable/model',


### PR DESCRIPTION
This PR fixes the "class variable is overtaken" error.

https://rubyreferences.github.io/rubychanges/3.0.html#changes-in-class-variable-behavior

> When class @@variable is overwritten by the parent of the class, or by the module included, the error is raised. In addition, top-level class variable access also raises an error.
