### PR TITLE
Fix #valid_controller? controller from mapping

### DIFF
--- a/lib/devise/autosigninable/strategy.rb
+++ b/lib/devise/autosigninable/strategy.rb
@@ -18,7 +18,7 @@ module Devise
       protected
 
       def valid_controller?
-        'devise/autosignin' == params[:controller]
+        mapping.controllers[:autosignin] == params[:controller]
       end
 
       def valid_params?


### PR DESCRIPTION
Сейчас если попробовать переопределить контроллер в `routes.rb` то эта проверка дальше не пропустит. 